### PR TITLE
Fix index updates: clear old index and avoid write amplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for v0.x
 
+## v0.3.1 (2024-10-24)
+
+### Bug fixes
+
+* Fixed consistency issue with index updates. Previously, the old index key was still queryable.
+* Fixed write amplification issue when updating struct's non-indexed fields.
+
 ## v0.3 (2024-10-20)
 
 ### \*\* Major breaking changes \*\*

--- a/lib/ecto_foundationdb/indexer/default.ex
+++ b/lib/ecto_foundationdb/indexer/default.ex
@@ -128,7 +128,6 @@ defmodule EctoFoundationDB.Indexer.Default do
   @impl true
   def set(tenant, tx, idx, schema, kv) do
     {index_key, index_object} = get_index_entry(tenant, idx, schema, kv)
-
     :erlfdb.set(tx, index_key, index_object)
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoFoundationdb.MixProject do
   def project do
     [
       app: :ecto_foundationdb,
-      version: "0.3.0",
+      version: "0.3.1",
       description: "FoundationDB adapter for Ecto",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,

--- a/test/ecto/integration/fdb_api_counting_test.exs
+++ b/test/ecto/integration/fdb_api_counting_test.exs
@@ -238,10 +238,6 @@ defmodule Ecto.Integration.FdbApiCountingTest do
              # set data in primary write
              {EctoFoundationDB.Layer.Tx, :set},
 
-             # clear and set default index. @todo, no index has changed, this is write amplification (#25)
-             {EctoFoundationDB.Indexer.Default, :clear},
-             {EctoFoundationDB.Indexer.Default, :set},
-
              # wait for max_version and claim_key
              {EctoFoundationDB.Layer.IndexInventory, :wait_for_all}
            ] == calls

--- a/test/ecto/integration/index_test.exs
+++ b/test/ecto/integration/index_test.exs
@@ -48,6 +48,8 @@ defmodule Ecto.Integration.IndexTest do
       |> User.changeset(%{name: "John"})
       |> TestRepo.update!()
 
+      assert nil == TestRepo.get_by(User, [name: "James"], prefix: tenant)
+
       assert [%User{name: "John"}, %User{name: "John"}] =
                from(u in User, where: u.name == ^"John")
                |> TestRepo.all(prefix: tenant)


### PR DESCRIPTION
While implementing the fix for #25 , I found that index updates were actually broken. Added a new test to verify consistency.