### PR TITLE
fix struct for pattern matching in limit

### DIFF
--- a/lib/ecto/adapters/foundationdb/ecto_adapter_queryable.ex
+++ b/lib/ecto/adapters/foundationdb/ecto_adapter_queryable.ex
@@ -165,7 +165,7 @@ defmodule Ecto.Adapters.FoundationDB.EctoAdapterQueryable do
 
   # Extract limit from an `Ecto.Query`
   defp get_limit(nil), do: nil
-  defp get_limit(%Ecto.Query.QueryExpr{expr: limit}), do: limit
+  defp get_limit(%Ecto.Query.LimitExpr{expr: limit}), do: limit
 
   defp assert_tenancy!(
          query = %Ecto.Query{


### PR DESCRIPTION
I hit the error below, and changing the struct to `Ecto.Query.LimitExpr` does fix the issue. All tests still pass. I'm not sure what I'm doing differently in my app to hit this error when your tests still pass in `main`.

```
iex(25)> MyApp.Db.Fdb.Repo.all(query, prefix: tenant)
** (FunctionClauseError) no function clause matching in Ecto.Adapters.FoundationDB.EctoAdapterQueryable.get_limit/1    
    
    The following arguments were given to Ecto.Adapters.FoundationDB.EctoAdapterQueryable.get_limit/1:
    
        # 1
        %Ecto.Query.LimitExpr{
          expr: 1,
          file: "iex",
          line: 23,
          with_ties: false,
          params: nil
        }
    
    Attempted function clauses (showing 2 out of 2):
    
        defp get_limit(nil)
        defp get_limit(%Ecto.Query.QueryExpr{expr: limit})
    
    (ecto_foundationdb 0.6.0) lib/ecto/adapters/foundationdb/ecto_adapter_queryable.ex:167: Ecto.Adapters.FoundationDB.EctoAdapterQueryable.get_limit/1
    (ecto_foundationdb 0.6.0) lib/ecto/adapters/foundationdb/ecto_adapter_queryable.ex:26: Ecto.Adapters.FoundationDB.EctoAdapterQueryable.prepare/2
    (ecto 3.13.5) lib/ecto/query/planner.ex:202: Ecto.Query.Planner.query_without_cache/4
    (ecto 3.13.5) lib/ecto/query/planner.ex:170: Ecto.Query.Planner.query_prepare/6
    (ecto 3.13.5) lib/ecto/query/planner.ex:143: Ecto.Query.Planner.query_with_cache/8
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:223: Ecto.Repo.Queryable.execute/4
    (ecto 3.13.5) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
    iex:25: (file)
```

edit: I didn't post my query:
```
query = from(
  e in MyApp.Db.Fdb.JobEvent,
  where: e.inserted_at >= ^prior_time,
  order_by: [desc: e.inserted_at],
  limit: 1)
```