### PR TITLE
Fix Versionstamp.from_integer/2 converstion of integer that is not 12…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.3 (2026-04-06)
+
+### Bug fixes
+
+* Fixed `Versionstamp.from_integer/1` raising `FunctionClauseError` when the versionstamp id has leading zero bytes.
+
 ## v0.7.2 (2026-04-05)
 
 ### Bug fixes

--- a/lib/ecto_foundationdb/versionstamp.ex
+++ b/lib/ecto_foundationdb/versionstamp.ex
@@ -55,7 +55,8 @@ defmodule EctoFoundationDB.Versionstamp do
 
   def from_integer(int) when is_integer(int) do
     bin = :binary.encode_unsigned(int, :big)
-    {vs} = :erlfdb_tuple.unpack(<<@vs96>> <> bin)
+    padding = :binary.copy(<<0>>, 12 - byte_size(bin))
+    {vs} = :erlfdb_tuple.unpack(<<@vs96>> <> padding <> bin)
     vs
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoFoundationdb.MixProject do
   def project do
     [
       app: :ecto_foundationdb,
-      version: "0.7.2",
+      version: "0.7.3",
       description: "FoundationDB adapter for Ecto",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,

--- a/test/ecto_foundationdb/versionstamp_test.exs
+++ b/test/ecto_foundationdb/versionstamp_test.exs
@@ -1,0 +1,28 @@
+defmodule EctoFoundationDB.VersionstampTest do
+  use ExUnit.Case, async: true
+
+  alias EctoFoundationDB.Versionstamp
+
+  describe "to_integer/1 and from_integer/1 roundtrip" do
+    test "roundtrips a versionstamp where the id has leading zero bytes" do
+      # id=121919289961 is 5 bytes, leaving 3 leading zero bytes when stored as 8 bytes.
+      # This triggered a FunctionClauseError in from_integer/1 because encode_unsigned
+      # strips leading zeros, producing a 10-byte binary instead of the required 12.
+      vs = {:versionstamp, 121_919_289_961, 0, 0}
+      int = Versionstamp.to_integer(vs)
+      assert Versionstamp.from_integer(int) == vs
+    end
+
+    test "roundtrips a versionstamp with a large id (no leading zero bytes)" do
+      vs = {:versionstamp, 0xFFFFFFFFFFFFFFFF - 1, 0xFFFE, 42}
+      int = Versionstamp.to_integer(vs)
+      assert Versionstamp.from_integer(int) == vs
+    end
+
+    test "roundtrips a versionstamp with zero id" do
+      vs = {:versionstamp, 0, 0, 0}
+      int = Versionstamp.to_integer(vs)
+      assert Versionstamp.from_integer(int) == vs
+    end
+  end
+end


### PR DESCRIPTION
… bytes wide

Fixes #90 