### PR TITLE
Add support for Versionstamp to include a spatial partition in the Tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.7.5 (TBD)
+
+### Enhancements
+
+* Versionstamp primary keys now support an optional `partition_by:` type option. When set, records with the same
+  value for the designated field are co-located in the FDB keyspace, enabling efficient single-partition
+  range scans via `{partition_value, id}` query parameters. `Repo.delete` and `Repo.update` raise
+  `Unsupported` for partitioned schemas; use `delete_all` / `update_all` with a compound key constraint
+  instead. Changing the `partition_by:` field on an existing record is also unsupported.
+
+  ```elixir
+  @primary_key {:id, EctoFoundationDB.Versionstamp, partition_by: :user_id, autogenerate: false}
+  ```
+
+* `EctoFoundationDB.Versionstamp` is now an `Ecto.ParameterizedType`. Existing schemas using bare
+  `Versionstamp` as the type continue to work unchanged. This change is backwards compatible with
+  existing data.
+
 ## v0.7.4 (2026-04-13)
 
 ### Bug fixes

--- a/lib/ecto/adapters/foundationdb.ex
+++ b/lib/ecto/adapters/foundationdb.ex
@@ -631,6 +631,80 @@ defmodule Ecto.Adapters.FoundationDB do
    - Records inserted in different transactions **will not** have a predictable versionstamp distance from each other. That distance
      is very unlikely to ever be 1.
 
+  ### Partition-by
+
+  Versionstamp primary keys are strictly ordered across the entire (Tenant, Schema). When you query a range of records
+  for a particular user or entity (e.g. all sessions for `"alice"`), FoundationDB must scan from a starting
+  key through all records until the desired end, potentially reading records along the way that would have to be
+  filtered out.
+
+  The `partition_by:` option solves this by prefixing the primary key with the value of a chosen field.
+  Records with the same field value are co-located in the keyspace, so a range query scoped to one value
+  is a single contiguous FDB GetRange with no extraneous data.
+
+  To configure, pass `partition_by:` as a type option on the primary key:
+
+  ```elixir
+  @primary_key {:id, EctoFoundationDB.Versionstamp, partition_by: :user_id, autogenerate: false}
+
+  schema "sessions" do
+    field :user_id, :string
+    field :data, :string
+  end
+  ```
+
+  #### Partition-scoped queries
+
+  Pass a `{partition_value, id}` tuple as the primary key parameter to scope a query to one partition:
+
+  ```elixir
+  # All of alice's sessions from a checkpoint onwards
+  Repo.all(
+    from(s in Session, where: s.id >= ^{"alice", checkpoint} and s.id < ^{"alice", Versionstamp.max()}),
+    prefix: tenant
+  )
+
+  # Alice's sessions between two checkpoints
+  Repo.all(
+    from(s in Session, where: s.id >= ^{"alice", first} and s.id <= ^{"alice", last}),
+    prefix: tenant
+  )
+
+  # Exact lookup by compound key
+  Repo.all(
+    from(s in Session, where: s.id == ^{"alice", alices_session_id}),
+    prefix: tenant
+  )
+  ```
+
+  A query with no partition constraint (e.g. `Repo.all(Session, prefix: tenant)`) performs a full scan
+  across all partitions and returns all records.
+
+  #### Mutations on partitioned schemas
+
+  `Repo.delete` and `Repo.update` are not supported for schemas with `partition_by:`, because the Ecto
+  adapter protocol does not provide the partition field value for those callbacks. Use `delete_all` and
+  `update_all` with a compound key constraint instead:
+
+  ```elixir
+  # Delete one record
+  Repo.delete_all(
+    from(s in Session, where: s.id == ^{session.user_id, session.id}),
+    prefix: tenant
+  )
+
+  # Update a non-partition field
+  Repo.update_all(
+    from(s in Session, where: s.id == ^{session.user_id, session.id}),
+    [set: [data: "new value"]],
+    prefix: tenant
+  )
+  ```
+
+  The `partition_by:` field value cannot be changed on an existing record. Attempting to do so via
+  `update_all` raises `EctoFoundationDB.Exception.Unsupported`. To move a record to a different
+  partition, delete it and re-insert it with the new value.
+
   ## Watches
 
   [FoundationDB Watches](https://apple.github.io/foundationdb/developer-guide.html#watches) are

--- a/lib/ecto/adapters/foundationdb/ecto_adapter_async.ex
+++ b/lib/ecto/adapters/foundationdb/ecto_adapter_async.ex
@@ -32,7 +32,7 @@ defmodule Ecto.Adapters.FoundationDB.EctoAdapterAsync do
 
         x =
           if is_nil(pk) and
-               schema.__schema__(:type, pk_field) == Versionstamp do
+               Versionstamp.type?(schema.__schema__(:type, pk_field)) do
             Map.put(x, pk_field, Versionstamp.next(tx))
           else
             x

--- a/lib/ecto_foundationdb/layer/pack.ex
+++ b/lib/ecto_foundationdb/layer/pack.ex
@@ -97,6 +97,28 @@ defmodule EctoFoundationDB.Layer.Pack do
   end
 
   @doc """
+  This function computes a key for use in FDB for a partitioned primary key.
+
+  For partitioned schemas, the key encodes both the partition value and the primary key id,
+  giving the key structure `{adapter_prefix, source, "d", partition_value, id}`.
+
+  ## Examples
+
+    iex> alias EctoFoundationDB.Layer.PrimaryKVCodec
+    iex> tenant = %EctoFoundationDB.Tenant{backend: EctoFoundationDB.Tenant.ManagedTenant}
+    iex> %{packed: packed} = EctoFoundationDB.Layer.Pack.primary_codec(tenant, "my-source", "alice", "my-id") |> PrimaryKVCodec.with_packed_key()
+    iex> EctoFoundationDB.Tenant.unpack(tenant, packed)
+    {"\\xFD", "my-source", "d", "alice", "my-id"}
+  """
+  def primary_codec(tenant, source, partition_value, id) do
+    namespaced_tuple(source, @data_namespace, [
+      encode_pk_for_key(partition_value),
+      encode_pk_for_key(id)
+    ])
+    |> then(&Tenant.primary_codec(tenant, &1, Versionstamp.incomplete?(id)))
+  end
+
+  @doc """
   ## Examples
 
     iex> tenant = %EctoFoundationDB.Tenant{backend: EctoFoundationDB.Tenant.ManagedTenant}
@@ -105,6 +127,19 @@ defmodule EctoFoundationDB.Layer.Pack do
   """
   def primary_range(tenant, source) do
     namespaced_range(tenant, source, @data_namespace, [])
+  end
+
+  @doc """
+  Returns the key range for all primary data within a specific partition value.
+
+  ## Examples
+
+    iex> tenant = %EctoFoundationDB.Tenant{backend: EctoFoundationDB.Tenant.ManagedTenant}
+    iex> EctoFoundationDB.Layer.Pack.primary_range(tenant, "my-source", "alice")
+    {"\\x01\\xFD\\0\\x01my-source\\0\\x01d\\0\\x01alice\\0\\0", "\\x01\\xFD\\0\\x01my-source\\0\\x01d\\0\\x01alice\\0\\xFF"}
+  """
+  def primary_range(tenant, source, partition_value) do
+    namespaced_range(tenant, source, @data_namespace, [encode_pk_for_key(partition_value)])
   end
 
   @doc """

--- a/lib/ecto_foundationdb/layer/query.ex
+++ b/lib/ecto_foundationdb/layer/query.ex
@@ -12,6 +12,10 @@ defmodule EctoFoundationDB.Layer.Query do
   alias EctoFoundationDB.QueryPlan
   alias EctoFoundationDB.Schema
 
+  # Sentinel for "no partition info in param". Distinct from nil so a nil partition
+  # value (while inadvisable) does not interfere with this logic.
+  @no_partition :__no_partition__
+
   defstruct [:idx, :range, :backward?]
 
   @doc """
@@ -275,7 +279,10 @@ defmodule EctoFoundationDB.Layer.Query do
          },
          _options
        ) do
-    kv_codec = Pack.primary_codec(tenant, plan.source, param)
+    partition_field = get_plan_partition_by_field(plan)
+    assert_compound_param!(param, partition_field, plan)
+    {partition_value, id} = split_partition_param(param, partition_field)
+    kv_codec = build_primary_codec(tenant, plan.source, partition_value, id)
     layer_data = %{layer_data | range: PrimaryKVCodec.range(kv_codec)}
     %{plan | layer_data: layer_data}
   end
@@ -293,20 +300,57 @@ defmodule EctoFoundationDB.Layer.Query do
       inclusive_right?: inclusive_right?
     } = between
 
+    partition_field = get_plan_partition_by_field(plan)
+
+    assert_compound_param!(param_left, partition_field, plan)
+    assert_compound_param!(param_right, partition_field, plan)
+
+    if partition_field && (is_nil(param_left) || is_nil(param_right)) do
+      pk_field = Fields.get_pk_field!(plan.schema)
+
+      raise Unsupported, """
+      Single-sided range queries are not supported on partitioned Versionstamp fields.
+
+      An open-ended >= or <= on a partitioned field is ambiguous: it is unclear
+      whether the intent is to stay within one partition or to span partitions.
+
+      To scan within a single partition, use both bounds with the same partition value:
+
+          from(s in #{inspect(plan.schema)},
+            where: s.#{pk_field} >= ^{partition_value, Versionstamp.min()} and
+                   s.#{pk_field} <= ^{partition_value, Versionstamp.max()})
+
+      To scan across partitions, either use a full-table scan:
+
+          Repo.all(#{inspect(plan.schema)}, prefix: tenant)
+
+      Or define the bounding partitions:
+
+          from(s in #{inspect(plan.schema)},
+            where: s.#{pk_field} >= ^{partition_value_a, Versionstamp.min()} and
+                   s.#{pk_field} <= ^{partition_value_b, Versionstamp.max()})
+      """
+    end
+
+    {left_partition, actual_left} = split_partition_param(param_left, partition_field)
+    {right_partition, actual_right} = split_partition_param(param_right, partition_field)
+
     {left_range_start, left_range_end} =
-      if is_nil(param_left) do
-        Pack.primary_range(tenant, plan.source)
+      if is_nil(actual_left) do
+        build_primary_range(tenant, plan.source, left_partition)
       else
-        codec_left = Pack.primary_codec(tenant, plan.source, param_left)
-        PrimaryKVCodec.range(codec_left)
+        PrimaryKVCodec.range(
+          build_primary_codec(tenant, plan.source, left_partition, actual_left)
+        )
       end
 
     {right_range_start, right_range_end} =
-      if is_nil(param_right) do
-        Pack.primary_range(tenant, plan.source)
+      if is_nil(actual_right) do
+        build_primary_range(tenant, plan.source, right_partition)
       else
-        codec_right = Pack.primary_codec(tenant, plan.source, param_right)
-        PrimaryKVCodec.range(codec_right)
+        PrimaryKVCodec.range(
+          build_primary_codec(tenant, plan.source, right_partition, actual_right)
+        )
       end
 
     start_key = if inclusive_left?, do: left_range_start, else: left_range_end
@@ -319,6 +363,63 @@ defmodule EctoFoundationDB.Layer.Query do
 
   defp make_datakey_range(_plan, _options) do
     raise Unsupported, "Between query must have binary parameters"
+  end
+
+  # Returns the partition field name from the plan's schema, or nil if not partitioned.
+  defp get_plan_partition_by_field(%QueryPlan{schema: nil}), do: nil
+
+  defp get_plan_partition_by_field(%QueryPlan{schema: schema}) do
+    Schema.get_partition_by_field(schema)
+  end
+
+  # Raises if a partitioned schema receives a param that is not a compound
+  # {partition_value, versionstamp} tuple (or nil, which is handled separately).
+  defp assert_compound_param!(nil, _partition_field, _plan), do: :ok
+  defp assert_compound_param!(_param, nil, _plan), do: :ok
+
+  defp assert_compound_param!({_, {:versionstamp, _, _, _}}, _partition_field, _plan), do: :ok
+
+  defp assert_compound_param!(param, partition_field, plan) do
+    pk_field = Fields.get_pk_field!(plan.schema)
+
+    raise Unsupported, """
+    Queries on partitioned Versionstamp schemas require a compound \
+    {partition_value, versionstamp} parameter for field #{inspect(pk_field)}.
+
+    Received: #{inspect(param)}
+
+    The partition field is #{inspect(partition_field)}. Without the partition value, \
+    the record cannot be located in its keyspace. Use:
+
+        ^{partition_value, id}
+    """
+  end
+
+  # Splits a query param into {partition_value_or_nil, id_or_nil}.
+  # When partition is configured and the param is a 2-tuple, the first element is the
+  # partition value and the second is the primary key id.
+  defp split_partition_param(nil, _partition_field), do: {@no_partition, nil}
+
+  defp split_partition_param({partition_value, id}, partition_field)
+       when not is_nil(partition_field),
+       do: {partition_value, id}
+
+  defp split_partition_param(id, _partition_field), do: {@no_partition, id}
+
+  defp build_primary_codec(tenant, source, @no_partition, id) do
+    Pack.primary_codec(tenant, source, id)
+  end
+
+  defp build_primary_codec(tenant, source, partition_value, id) do
+    Pack.primary_codec(tenant, source, partition_value, id)
+  end
+
+  defp build_primary_range(tenant, source, @no_partition) do
+    Pack.primary_range(tenant, source)
+  end
+
+  defp build_primary_range(tenant, source, partition_value) do
+    Pack.primary_range(tenant, source, partition_value)
   end
 
   defp backward?(plan = %{layer_data: layer_data = %__MODULE__{idx: idx}}, ordering, _options)

--- a/lib/ecto_foundationdb/layer/tx.ex
+++ b/lib/ecto_foundationdb/layer/tx.ex
@@ -148,6 +148,21 @@ defmodule EctoFoundationDB.Layer.Tx do
         options
       ) do
     write_primary = Schema.get_option(context, :write_primary)
+    partition_field = Schema.get_partition_by_field(schema)
+
+    if partition_field do
+      raise Unsupported, """
+      Repo.update is not supported for schemas with a partition field (#{inspect(partition_field)}).
+
+      Use Repo.update_all with a compound primary key constraint instead:
+
+          Repo.update_all(
+            from(s in #{inspect(schema)}, where: s.id == ^{partition_value, id}),
+            [set: [field: value]],
+            prefix: tenant
+          )
+      """
+    end
 
     futures =
       Enum.map(pks, fn pk ->
@@ -196,6 +211,8 @@ defmodule EctoFoundationDB.Layer.Tx do
     %DecodedKV{codec: kv_codec, data_object: orig_data_object} = decoded_kv
     orig_data_object = Fields.to_front(orig_data_object, pk_field)
 
+    assert_partition_by_unchanged!(schema, orig_data_object, updates)
+
     data_object =
       orig_data_object
       |> Keyword.merge(updates[:set] || [])
@@ -220,6 +237,21 @@ defmodule EctoFoundationDB.Layer.Tx do
   end
 
   def delete_pks(tenant, tx, {schema, source, _context}, pks, metadata) do
+    partition_field = Schema.get_partition_by_field(schema)
+
+    if partition_field do
+      raise Unsupported, """
+      Repo.delete is not supported for schemas with a partition field (#{inspect(partition_field)}).
+
+      Use Repo.delete_all with a compound primary key constraint instead:
+
+          Repo.delete_all(
+            from(s in #{inspect(schema)}, where: s.id == ^{partition_value, id}),
+            prefix: tenant
+          )
+      """
+    end
+
     futures =
       Enum.map(pks, fn pk ->
         kv_codec = Pack.primary_codec(tenant, source, pk)
@@ -270,6 +302,32 @@ defmodule EctoFoundationDB.Layer.Tx do
     end
 
     Indexer.clear(tenant, tx, metadata, schema, {kv_codec, v})
+  end
+
+  defp assert_partition_by_unchanged!(nil, _orig, _updates), do: :ok
+
+  defp assert_partition_by_unchanged!(schema, orig_data_object, updates) do
+    partition_field = Schema.get_partition_by_field(schema)
+
+    if partition_field do
+      orig_value = orig_data_object[partition_field]
+      updates_set = updates[:set] || []
+
+      case Keyword.fetch(updates_set, partition_field) do
+        {:ok, new_value} when new_value != orig_value ->
+          raise Unsupported, """
+          Cannot change the partition_by field #{inspect(partition_field)} on a schema with partition support.
+
+          The field #{inspect(partition_field)} determines the keyspace partition for this record.
+          Changing it would require moving the record to a different partition, which is not supported.
+
+          To move a record to a different partition, delete it and re-insert it with the new partition value.
+          """
+
+        _ ->
+          :ok
+      end
+    end
   end
 
   def clear_all(tenant, tx, %{opts: _adapter_opts}, source) do

--- a/lib/ecto_foundationdb/layer/tx_insert.ex
+++ b/lib/ecto_foundationdb/layer/tx_insert.ex
@@ -7,6 +7,7 @@ defmodule EctoFoundationDB.Layer.TxInsert do
   alias EctoFoundationDB.Layer.Pack
   alias EctoFoundationDB.Layer.PrimaryKVCodec
   alias EctoFoundationDB.Layer.Tx
+  alias EctoFoundationDB.Schema
 
   defstruct [:tenant, :schema, :source, :metadata, :write_primary, :options]
 
@@ -29,10 +30,20 @@ defmodule EctoFoundationDB.Layer.TxInsert do
       ) do
     %__MODULE__{
       tenant: tenant,
-      source: source
+      source: source,
+      schema: schema
     } = acc
 
-    kv_codec = Pack.primary_codec(tenant, source, pk)
+    partition_field = Schema.get_partition_by_field(schema)
+
+    kv_codec =
+      if partition_field do
+        partition_value = Keyword.get(data_object, partition_field)
+        Pack.primary_codec(tenant, source, partition_value, pk)
+      else
+        Pack.primary_codec(tenant, source, pk)
+      end
+
     read_before_write = if kv_codec.vs?, do: false, else: read_before_write
     data_object = [{pk_field, pk} | Keyword.delete(data_object, pk_field)]
     kv = %DecodedKV{codec: kv_codec, data_object: data_object, multikey?: false, range: nil}

--- a/lib/ecto_foundationdb/schema.ex
+++ b/lib/ecto_foundationdb/schema.ex
@@ -1,6 +1,8 @@
 defmodule EctoFoundationDB.Schema do
   @moduledoc false
 
+  alias EctoFoundationDB.Versionstamp
+
   def get_context!(_source, schema) when is_atom(schema) and not is_nil(schema) do
     %{__meta__: _meta = %{context: context}} = Kernel.struct!(schema)
     context
@@ -25,4 +27,20 @@ defmodule EctoFoundationDB.Schema do
 
   def get_option(nil, _key, default), do: default
   def get_option(context, key, default), do: Keyword.get(context, key, default)
+
+  @doc false
+  def get_partition_by_field(schema) when is_atom(schema) and not is_nil(schema) do
+    case schema.__schema__(:primary_key) do
+      [pk_field | _] ->
+        case schema.__schema__(:type, pk_field) do
+          {:parameterized, {Versionstamp, %{partition_by: p}}} when not is_nil(p) -> p
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  def get_partition_by_field(_schema), do: nil
 end

--- a/lib/ecto_foundationdb/versionstamp.ex
+++ b/lib/ecto_foundationdb/versionstamp.ex
@@ -1,11 +1,24 @@
 defmodule EctoFoundationDB.Versionstamp do
   @moduledoc """
-  Versionstamping is a feature that allows you to create a unique identifier for a record
+  Versionstamping is a feature that allows you to create a identifier for a record
   that is guaranteed to be unique across all records in the database.
 
-  Please refer to the documentation for `Repo.async_insert_all!/3`.
+  Please refer to the documentation for `Repo.async_insert_all!/3` for instructions
+  on how to insert records with a Versionstamp primary key.
+
+  ## Partition-by option
+
+  When used as a primary key type, an optional `partition_by:` option can be provided to
+  co-locate records with the same field value in the same keyspace:
+
+      @primary_key {:id, {EctoFoundationDB.Versionstamp, partition_by: :user_id}, autogenerate: false}
+
+  This enables efficient single-partition range scans:
+
+      from(s in Session, where: s.id >= ^{"alice", checkpoint} and s.id < ^{"alice", Versionstamp.max()})
+      |> Repo.all(prefix: tenant)
   """
-  use Ecto.Type
+  use Ecto.ParameterizedType
 
   alias EctoFoundationDB.Exception.Unsupported
   alias EctoFoundationDB.Future
@@ -14,19 +27,33 @@ defmodule EctoFoundationDB.Versionstamp do
   # From :erlfdb_tuple
   @vs80 0x32
   @vs96 0x33
-  @inc_id 0xFFFFFFFFFFFFFFFF
-  @inc_batch 0xFFFF
+  @max_id 0xFFFFFFFFFFFFFFFF
+  @max_batch 0xFFFF
+  @max_user 0xFFFF
 
-  def incomplete(user) do
-    {:versionstamp, @inc_id, @inc_batch, user}
-  end
+  @inc_id @max_id
+  @inc_batch @max_batch
 
+  def incomplete(user), do: {:versionstamp, @inc_id, @inc_batch, user}
+  def max(), do: {:versionstamp, @max_id, @max_batch, @max_user}
+  def min(), do: {:versionstamp, 0, 0, 0}
+
+  def incomplete?({:versionstamp, @max_id, @max_batch, @max_user}), do: false
   def incomplete?({:versionstamp, @inc_id, @inc_batch, _}), do: true
   def incomplete?(_), do: false
+
+  @doc """
+  Returns true if the given value is a parameterized Versionstamp type term,
+  as returned by `schema.__schema__(:type, field)`.
+  """
+  def type?({:parameterized, {__MODULE__, _}}), do: true
+  def type?(_), do: false
 
   def get(tx) do
     Future.new(:erlfdb_future, :erlfdb.get_versionstamp(tx), &from_binary/1)
   end
+
+  def to_integer(vs = {:versionstamp, @max_id, @max_batch, @max_user}), do: to_integer_(vs)
 
   def to_integer({:versionstamp, @inc_id, @inc_batch, _}) do
     raise Unsupported, """
@@ -48,7 +75,9 @@ defmodule EctoFoundationDB.Versionstamp do
     """
   end
 
-  def to_integer(vs = {:versionstamp, _, _, _}) do
+  def to_integer(vs = {:versionstamp, _, _, _}), do: to_integer_(vs)
+
+  defp to_integer_(vs = {:versionstamp, _, _, _}) do
     <<@vs96, bin::binary>> = :erlfdb_tuple.pack({vs})
     :binary.decode_unsigned(bin, :big)
   end
@@ -84,17 +113,38 @@ defmodule EctoFoundationDB.Versionstamp do
   end
 
   @impl true
-  def type(), do: :id
+  def init(opts) do
+    %{partition_by: Keyword.get(opts, :partition_by)}
+  end
 
   @impl true
-  def cast(id) when is_integer(id), do: {:ok, from_integer(id)}
-  def cast(vs = {:versionstamp, _, _, _}), do: {:ok, vs}
-  def cast(id_str) when is_binary(id_str), do: Ecto.Type.cast(:id, id_str)
-  def cast(_), do: :error
+  def type(_params), do: :id
 
   @impl true
-  def dump(vs = {:versionstamp, _, _, _}), do: {:ok, vs}
+  def cast(nil, _params), do: {:ok, nil}
+  def cast(id, _params) when is_integer(id), do: {:ok, from_integer(id)}
+  def cast(vs = {:versionstamp, _, _, _}, _params), do: {:ok, vs}
+  def cast(id_str, _params) when is_binary(id_str), do: Ecto.Type.cast(:id, id_str)
+
+  def cast({partition_value, vs = {:versionstamp, _, _, _}}, %{partition_by: partition_by})
+      when not is_nil(partition_by),
+      do: {:ok, {partition_value, vs}}
+
+  def cast(_, _params), do: :error
 
   @impl true
-  def load(vs = {:versionstamp, _, _, _}), do: {:ok, vs}
+  def dump(nil, _dumper, _params), do: {:ok, nil}
+  def dump(vs = {:versionstamp, _, _, _}, _dumper, _params), do: {:ok, vs}
+
+  def dump({partition_value, vs = {:versionstamp, _, _, _}}, _dumper, %{
+        partition_by: partition_by
+      })
+      when not is_nil(partition_by),
+      do: {:ok, {partition_value, vs}}
+
+  def dump(_, _, _), do: :error
+
+  @impl true
+  def load(vs = {:versionstamp, _, _, _}, _loader, _params), do: {:ok, vs}
+  def load(_, _, _), do: :error
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoFoundationdb.MixProject do
   def project do
     [
       app: :ecto_foundationdb,
-      version: "0.7.4",
+      version: "0.7.5",
       description: "FoundationDB adapter for Ecto",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,

--- a/test/ecto/integration/partition_test.exs
+++ b/test/ecto/integration/partition_test.exs
@@ -1,0 +1,347 @@
+defmodule Ecto.Integration.PartitionTest do
+  use Ecto.Integration.Case, async: true
+
+  import Ecto.Query
+
+  alias Ecto.Adapters.FoundationDB
+
+  alias EctoFoundationDB.Exception.Unsupported
+  alias EctoFoundationDB.Schemas.Session
+  alias EctoFoundationDB.Versionstamp
+
+  alias Ecto.Integration.TestRepo
+
+  describe "partitioned versionstamp primary key" do
+    test "insert stores records in partition-scoped keyspace", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "a1"},
+            %Session{user_id: "alice", data: "a2"},
+            %Session{user_id: "bob", data: "b1"}
+          ])
+        end)
+
+      [alice1, alice2, bob1] = TestRepo.await(future)
+
+      assert alice1.user_id == "alice"
+      assert alice2.user_id == "alice"
+      assert bob1.user_id == "bob"
+
+      # All three are retrievable
+      all = TestRepo.all(Session, prefix: tenant)
+      assert length(all) == 3
+    end
+
+    test "single-sided inequality raises Unsupported on partitioned schemas", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "a1"},
+            %Session{user_id: "alice", data: "a2"}
+          ])
+        end)
+
+      [alice1, _alice2] = TestRepo.await(future)
+
+      assert_raise Unsupported, ~r/Single-sided range queries are not supported/, fn ->
+        TestRepo.all(from(s in Session, where: s.id >= ^{"alice", alice1.id}), prefix: tenant)
+      end
+
+      assert_raise Unsupported, ~r/Single-sided range queries are not supported/, fn ->
+        TestRepo.all(from(s in Session, where: s.id <= ^{"alice", alice1.id}), prefix: tenant)
+      end
+    end
+
+    test "Versionstamp.min() and max() together scan an entire partition", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "a1"},
+            %Session{user_id: "alice", data: "a2"},
+            %Session{user_id: "bob", data: "b1"}
+          ])
+        end)
+
+      [alice1, alice2, _bob1] = TestRepo.await(future)
+
+      # min() as the lower bound and max() as the upper bound together cover
+      # all of alice's records without crossing into bob's partition.
+      results =
+        TestRepo.all(
+          from(s in Session,
+            where:
+              s.id >= ^{"alice", Versionstamp.min()} and s.id <= ^{"alice", Versionstamp.max()}
+          ),
+          prefix: tenant
+        )
+
+      assert results == [alice1, alice2]
+      assert Enum.all?(results, fn s -> s.user_id == "alice" end)
+    end
+
+    test "Versionstamp.max() as upper bound scopes query from a checkpoint to end of partition",
+         context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "a1"},
+            %Session{user_id: "alice", data: "a2"},
+            %Session{user_id: "bob", data: "b1"}
+          ])
+        end)
+
+      [alice1, alice2, _bob1] = TestRepo.await(future)
+
+      # Using max() keeps the scan within alice's partition even though
+      # {"bob", _} > {"alice", _} would otherwise be included by an open-ended >=.
+      results =
+        TestRepo.all(
+          from(s in Session,
+            where: s.id >= ^{"alice", alice1.id} and s.id <= ^{"alice", Versionstamp.max()}
+          ),
+          prefix: tenant
+        )
+
+      assert results == [alice1, alice2]
+      assert Enum.all?(results, fn s -> s.user_id == "alice" end)
+    end
+
+    test "range query with both bounds stays within partition", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "a1"},
+            %Session{user_id: "alice", data: "a2"},
+            %Session{user_id: "alice", data: "a3"}
+          ])
+        end)
+
+      [a1, a2, _a3] = TestRepo.await(future)
+
+      # Range query between two checkpoints for alice
+      results =
+        TestRepo.all(
+          from(s in Session, where: s.id >= ^{"alice", a1.id} and s.id <= ^{"alice", a2.id}),
+          prefix: tenant
+        )
+
+      assert length(results) == 2
+      assert Enum.all?(results, fn s -> s.user_id == "alice" end)
+    end
+
+    test "equality query with partition key gets exact record", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "target"},
+            %Session{user_id: "bob", data: "other"}
+          ])
+        end)
+
+      [alice, _bob] = TestRepo.await(future)
+
+      # Get exact session using compound {partition, id} param
+      results =
+        TestRepo.all(
+          from(s in Session, where: s.id == ^{"alice", alice.id}),
+          prefix: tenant
+        )
+
+      assert [%Session{data: "target"}] = results
+    end
+
+    test "Repo.get with compound pk returns the record", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "target"},
+            %Session{user_id: "bob", data: "other"}
+          ])
+        end)
+
+      [alice, _bob] = TestRepo.await(future)
+
+      # Compound {partition_value, id} locates the record in the correct keyspace.
+      assert %Session{data: "target"} =
+               TestRepo.get(Session, {"alice", alice.id}, prefix: tenant)
+
+      # A bare versionstamp without a partition value raises because the adapter
+      # cannot determine which partition keyspace to search.
+      assert_raise Unsupported, ~r/compound \{partition_value, versionstamp\} parameter/, fn ->
+        TestRepo.get(Session, alice.id, prefix: tenant)
+      end
+    end
+
+    test "delete_all with compound pk removes record", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "to-delete"},
+            %Session{user_id: "alice", data: "to-keep"}
+          ])
+        end)
+
+      [to_delete, _to_keep] = TestRepo.await(future)
+
+      TestRepo.delete_all(
+        from(s in Session, where: s.id == ^{to_delete.user_id, to_delete.id}),
+        prefix: tenant
+      )
+
+      remaining = TestRepo.all(Session, prefix: tenant)
+
+      assert Enum.all?(remaining, fn s -> s.data != "to-delete" end)
+    end
+
+    test "Repo.delete raises Unsupported for partitioned schemas", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "data"}
+          ])
+        end)
+
+      [session] = TestRepo.await(future)
+
+      assert_raise Unsupported, ~r/Repo.delete is not supported/, fn ->
+        TestRepo.delete!(session |> FoundationDB.usetenant(tenant))
+      end
+    end
+
+    test "update_all with compound pk changes non-partition fields", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "original"}
+          ])
+        end)
+
+      [session] = TestRepo.await(future)
+
+      # Update a non-partition field using a compound pk constraint
+      TestRepo.update_all(
+        from(s in Session, where: s.id == ^{session.user_id, session.id}),
+        [set: [data: "updated"]],
+        prefix: tenant
+      )
+
+      # Verify we can still query it
+      results =
+        TestRepo.all(
+          from(s in Session, where: s.id == ^{"alice", session.id}),
+          prefix: tenant
+        )
+
+      assert [%Session{data: "updated"}] = results
+    end
+
+    test "Repo.update raises Unsupported for partitioned schemas", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "data"}
+          ])
+        end)
+
+      [session] = TestRepo.await(future)
+
+      assert_raise Unsupported, ~r/Repo.update is not supported/, fn ->
+        session
+        |> FoundationDB.usetenant(tenant)
+        |> Ecto.Changeset.change(data: "updated")
+        |> TestRepo.update()
+      end
+    end
+
+    test "update_all raises when changing the partition field", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "data"}
+          ])
+        end)
+
+      [session] = TestRepo.await(future)
+
+      assert_raise Unsupported, ~r/Cannot change the partition_by field/, fn ->
+        TestRepo.update_all(
+          from(s in Session, where: s.id == ^{session.user_id, session.id}),
+          [set: [user_id: "bob"]],
+          prefix: tenant
+        )
+      end
+    end
+
+    test "multi-user insert + per-user scoped delete_all", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "a1"},
+            %Session{user_id: "alice", data: "a2"},
+            %Session{user_id: "bob", data: "b1"}
+          ])
+        end)
+
+      [_alice1, _alice2, _bob1] = TestRepo.await(future)
+
+      # Delete all of alice's sessions using a partition-scoped range
+      TestRepo.delete_all(
+        from(s in Session,
+          where: s.id >= ^{"alice", Versionstamp.min()} and s.id <= ^{"alice", Versionstamp.max()}
+        ),
+        prefix: tenant
+      )
+
+      remaining = TestRepo.all(Session, prefix: tenant)
+      assert Enum.all?(remaining, fn s -> s.user_id == "bob" end)
+    end
+
+    test "full scan returns records across all partitions", context do
+      tenant = context[:tenant]
+
+      future =
+        TestRepo.transactional(tenant, fn ->
+          TestRepo.async_insert_all!(Session, [
+            %Session{user_id: "alice", data: "a1"},
+            %Session{user_id: "bob", data: "b1"},
+            %Session{user_id: "charlie", data: "c1"}
+          ])
+        end)
+
+      TestRepo.await(future)
+
+      all = TestRepo.all(Session, prefix: tenant)
+      assert length(all) == 3
+
+      users = Enum.map(all, & &1.user_id) |> Enum.sort()
+      assert users == ["alice", "bob", "charlie"]
+    end
+  end
+end

--- a/test/ecto_foundationdb/versionstamp_test.exs
+++ b/test/ecto_foundationdb/versionstamp_test.exs
@@ -1,6 +1,7 @@
 defmodule EctoFoundationDB.VersionstampTest do
   use ExUnit.Case, async: true
 
+  alias EctoFoundationDB.Exception.Unsupported
   alias EctoFoundationDB.Versionstamp
 
   describe "to_integer/1 and from_integer/1 roundtrip" do
@@ -23,6 +24,43 @@ defmodule EctoFoundationDB.VersionstampTest do
       vs = {:versionstamp, 0, 0, 0}
       int = Versionstamp.to_integer(vs)
       assert Versionstamp.from_integer(int) == vs
+    end
+
+    test "roundtrips a versionstamp with max id" do
+      vs = {:versionstamp, 0xFFFFFFFFFFFFFFFF, 0xFFFF, 0xFFFF}
+      int = Versionstamp.to_integer(vs)
+      assert Versionstamp.from_integer(int) == vs
+    end
+
+    test "an incomplete versionstamp raises" do
+      vs = {:versionstamp, 0xFFFFFFFFFFFFFFFF, 0xFFFF, 42}
+
+      assert_raise Unsupported,
+                   ~r/Versionstamps must be completed before they are useful, so we disallow converting an incomplete versionstamp to an integer/,
+                   fn -> Versionstamp.to_integer(vs) end
+    end
+  end
+
+  describe "min/0 and max/0 sentinels" do
+    test "min() is less than any real versionstamp" do
+      real_vs = {:versionstamp, 1, 0, 0}
+      assert Versionstamp.to_integer(Versionstamp.min()) < Versionstamp.to_integer(real_vs)
+    end
+
+    test "max() is greater than any real versionstamp" do
+      # A real versionstamp has an 8-byte transaction id; the largest plausible
+      # value is well below the all-ones sentinel used by max().
+      large_vs = {:versionstamp, 0xFFFFFFFFFFFFFFFF - 1, 0xFFFE, 0xFFFE}
+      assert Versionstamp.to_integer(Versionstamp.max()) > Versionstamp.to_integer(large_vs)
+    end
+
+    test "max() is not considered incomplete" do
+      refute Versionstamp.incomplete?(Versionstamp.max())
+    end
+
+    test "incomplete() with any user value is considered incomplete" do
+      assert Versionstamp.incomplete?(Versionstamp.incomplete(0))
+      assert Versionstamp.incomplete?(Versionstamp.incomplete(42))
     end
   end
 end

--- a/test/support/schemas/session.ex
+++ b/test/support/schemas/session.ex
@@ -1,0 +1,14 @@
+defmodule EctoFoundationDB.Schemas.Session do
+  @moduledoc false
+
+  use Ecto.Schema
+
+  alias EctoFoundationDB.Versionstamp
+
+  @primary_key {:id, Versionstamp, partition_by: :user_id, autogenerate: false}
+
+  schema "sessions" do
+    field(:user_id, :string)
+    field(:data, :string)
+  end
+end


### PR DESCRIPTION
Closes #92 

EctoFoundationDB.Versionstamp is now an Ecto.ParameterizedType that supports an optional :partition_by field. This refers to a field on the schema that is treated as a spatial partition for those records in the given Tenant. This change is fully backward compatible.